### PR TITLE
Add 10 player capability

### DIFF
--- a/lib/pages/final_page.dart
+++ b/lib/pages/final_page.dart
@@ -37,7 +37,7 @@ class ScoreBoard extends StatelessWidget {
       builder: (context, playerProvider, child) {
         return SizedBox(
           width: 300,
-          height: 800,
+          height: 900,
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/pages/instructions_page.dart
+++ b/lib/pages/instructions_page.dart
@@ -227,6 +227,8 @@ class PlayerNameForm extends StatelessWidget {
   final _player6Controller = TextEditingController();
   final _player7Controller = TextEditingController();
   final _player8Controller = TextEditingController();
+  final _player9Controller = TextEditingController();
+  final _player10Controller = TextEditingController();
 
   bool _validateUniqueNames() {
     final names =
@@ -239,6 +241,8 @@ class PlayerNameForm extends StatelessWidget {
           _player6Controller.text.trim(),
           _player7Controller.text.trim(),
           _player8Controller.text.trim(),
+          _player9Controller.text.trim(),
+          _player10Controller.text.trim(),
         ].where((name) => name.isNotEmpty).toList(); // Filter out empty names
 
     final uniqueNames = names.toSet();
@@ -257,6 +261,8 @@ class PlayerNameForm extends StatelessWidget {
       _player6Controller.text.trim(),
       _player7Controller.text.trim(),
       _player8Controller.text.trim(),
+      _player9Controller.text.trim(),
+      _player10Controller.text.trim(),
     ];
 
     final nonEmptyNames = names.where((name) => name.isNotEmpty).toList();
@@ -357,6 +363,11 @@ class PlayerNameForm extends StatelessWidget {
                             controller: _player4Controller,
                             playerNumber: 4,
                           ),
+                          SizedBox(height: 16),
+                          PlayerTextField(
+                            controller: _player5Controller,
+                            playerNumber: 5,
+                          ),
                         ],
                       ),
                     ),
@@ -364,11 +375,6 @@ class PlayerNameForm extends StatelessWidget {
                     Expanded(
                       child: Column(
                         children: [
-                          PlayerTextField(
-                            controller: _player5Controller,
-                            playerNumber: 5,
-                          ),
-                          SizedBox(height: 16),
                           PlayerTextField(
                             controller: _player6Controller,
                             playerNumber: 6,
@@ -382,6 +388,16 @@ class PlayerNameForm extends StatelessWidget {
                           PlayerTextField(
                             controller: _player8Controller,
                             playerNumber: 8,
+                          ),
+                          SizedBox(height: 16),
+                          PlayerTextField(
+                            controller: _player9Controller,
+                            playerNumber: 9,
+                          ),
+                          SizedBox(height: 16),
+                          PlayerTextField(
+                            controller: _player10Controller,
+                            playerNumber: 10,
                           ),
                         ],
                       ),
@@ -430,6 +446,16 @@ class PlayerNameForm extends StatelessWidget {
                     PlayerTextField(
                       controller: _player8Controller,
                       playerNumber: 8,
+                    ),
+                    SizedBox(height: 16),
+                    PlayerTextField(
+                      controller: _player9Controller,
+                      playerNumber: 9,
+                    ),
+                    SizedBox(height: 16),
+                    PlayerTextField(
+                      controller: _player10Controller,
+                      playerNumber: 10,
                     ),
                   ],
                 );

--- a/test/qrow_test.dart
+++ b/test/qrow_test.dart
@@ -3,8 +3,13 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'dart:convert';
 import 'package:buzz5_quiz_app/models/qrow.dart';
+import 'package:buzz5_quiz_app/config/app_config.dart';
 
 void main() {
+  setUpAll(() async {
+    // Initialize AppConfig for tests
+    await AppConfig.initialize();
+  });
   group('QRow.fetchAll', () {
     test(
       'returns a list of QRow if the http call completes successfully',


### PR DESCRIPTION
## Summary by Sourcery

Extend the app to support up to ten players by adding new input fields and validation logic, update the final scoreboard to accommodate the additional players, and initialize application configuration for tests.

New Features:
- Support for up to 10 player name inputs in the instructions page.

Enhancements:
- Adjust layout and validation logic to include ninth and tenth player fields.
- Increase final scoreboard height to fit extra players.

Tests:
- Initialize AppConfig in qrow tests before execution.